### PR TITLE
Update CommonOptions.cs

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Design/Internal/CommonOptions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Design/Internal/CommonOptions.cs
@@ -18,9 +18,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Precompilation.Design.Internal
 
         public void Configure(CommandLineApplication app)
         {
-            app.Description = "Precompiles an application.";
-            app.HelpOption("-?|-h|--help");
-
             ProjectArgument = app.Argument(
                 "project",
                 "The path to the project (project folder or project.json) with precompilation.");


### PR DESCRIPTION
The additional `app.HelpOption` here prevents the application from displaying help when that option is passed due to the `CommandLineUtils` choking on the duplicated template; also, `PrecompilationApplication` already defines its own `HelpOption` and `Description`.