### PR TITLE
Add Microsoft.DotNet.InternalAbstractions to resolve runtime failure.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Tools/project.json
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Tools/project.json
@@ -27,7 +27,7 @@
     "Microsoft.AspNetCore.Mvc.Razor.Precompilation.Design": {
       "target": "project"
     },
-    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-003121",
     "Microsoft.Extensions.CommandLineUtils": "1.1.0-*",
     "Microsoft.Extensions.DotnetToolDispatcher.Sources": {
       "type": "build",
@@ -37,7 +37,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.DotNet.ProjectModel.Loader": "1.0.0-*",
+        "Microsoft.DotNet.InternalAbstractions": "1.0.0",
+        "Microsoft.DotNet.ProjectModel.Loader": "1.0.0-preview2-003121",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.1.0-*"


### PR DESCRIPTION
Pin the version of ProjectModel.Loader and Cli.Utils