### PR TITLE
Fix build break

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Internal/MvcServiceProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Internal/MvcServiceProvider.cs
@@ -9,12 +9,12 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.Razor.Internal;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Evolution;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
-using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Internal
 {


### PR DESCRIPTION
`MvcRazorTemplateEngine` was removed from the namespace `Microsoft.AspNetCore.Mvc.Razor`, it now lives in `Microsoft.AspNetCore.Mvc.Razor.Extensions`.