### PR TITLE
Update version numbers for 1.1.x

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Design/project.json
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Design/project.json
@@ -32,7 +32,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-*"
+          "version": "1.1.2-*"
         }
       }
     },

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Tools/project.json
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Tools/project.json
@@ -41,7 +41,7 @@
         "Microsoft.DotNet.ProjectModel.Loader": "1.0.0-preview2-003121",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-*"
+          "version": "1.1.2-*"
         },
         "System.Runtime.Serialization.Primitives": "4.3.0-*"
       }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Design.Test/project.json
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Design.Test/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-*"
+          "version": "1.1.2-*"
         }
       },
       "net451": {}

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Precompilation.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Precompilation.FunctionalTests/project.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-*"
+          "version": "1.1.2-*"
         }
       }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Tools.Test/project.json
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Precompilation.Tools.Test/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-*"
+          "version": "1.1.2-*"
         }
       },
       "net451": {}

--- a/testapps/ApplicationUsingPrecompiledViewClassLibrary/project.json
+++ b/testapps/ApplicationUsingPrecompiledViewClassLibrary/project.json
@@ -17,7 +17,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.1.2-*",
           "type": "platform"
         }
       }

--- a/testapps/ApplicationWithConfigureMvc/project.json
+++ b/testapps/ApplicationWithConfigureMvc/project.json
@@ -21,7 +21,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.1.2-*",
           "type": "platform"
         }
       }

--- a/testapps/ApplicationWithTagHelpers/project.json
+++ b/testapps/ApplicationWithTagHelpers/project.json
@@ -25,7 +25,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.1.2-*",
           "type": "platform"
         }
       }

--- a/testapps/ClassLibraryWithPrecompiledViews/project.json
+++ b/testapps/ClassLibraryWithPrecompiledViews/project.json
@@ -26,7 +26,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.1.2-*",
           "type": "platform"
         }
       }

--- a/testapps/PublishWithEmbedViewSources/project.json
+++ b/testapps/PublishWithEmbedViewSources/project.json
@@ -21,7 +21,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.1.2-*",
           "type": "platform"
         }
       }

--- a/testapps/SimpleApp/project.json
+++ b/testapps/SimpleApp/project.json
@@ -21,7 +21,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.1.2-*",
           "type": "platform"
         }
       }

--- a/testapps/StrongNamedApp/project.json
+++ b/testapps/StrongNamedApp/project.json
@@ -22,7 +22,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-*",
+          "version": "1.1.2-*",
           "type": "platform"
         }
       }


### PR DESCRIPTION
Looks like `Microsoft.NETCore.App` is the only one of the updated packages referenced directly here.