### PR TITLE
Enable net461 tests.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
@@ -11,11 +11,29 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <OutputType>exe</OutputType>
     <X86ProjectDirectory>..\..\tools\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation-x86\</X86ProjectDirectory>
+
+    <!--
+      This prevents dotnet from automatically generating a lib/tfm/*.dll; in turn we're then able
+      to exclude the lib/net461 and manually construct only the necessary folders:
+      - lib/netcoreapp2.0/...
+      - runtimes/win7-x64/lib/...
+      - runtimes/win7-x86/lib/...
+    -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="build\**\*" Pack="true" PackagePath="%(Identity)" />
-    <None Include="$(X86ProjectDirectory)\bin\$(Configuration)\net461\win7-x86\$(MSBuildThisFileName)-x86.exe" Pack="true" PackagePath="lib\net461\$(MSBuildThisFileName)-x86.exe" />
+    <None Include="build\common.targets" Pack="true" PackagePath="%(Identity)" />
+    <None Include="lib\net461\_._" Pack="true" PackagePath="%(Identity)" />
+    <None Include="build\netcoreapp2.0\*" Pack="true" PackagePath="%(Identity)" />
+    <None Include="bin\$(Configuration)\netcoreapp2.0\$(AssemblyName).dll" Pack="true" PackagePath="lib\netcoreapp2.0\$(AssemblyName).dll" />
+    <None Include="bin\$(Configuration)\netcoreapp2.0\$(AssemblyName).runtimeconfig.json" Pack="true" PackagePath="lib\netcoreapp2.0\$(AssemblyName).runtimeconfig.json" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <None Include="build\net461\*" Pack="true" PackagePath="%(Identity)" />
+    <None Include="bin\$(Configuration)\net461\win7-x64\$(AssemblyName).exe" Pack="true" PackagePath="runtimes\win7-x64\lib\net461\$(AssemblyName).exe" />
+    <None Include="$(X86ProjectDirectory)\bin\$(Configuration)\net461\win7-x86\$(AssemblyName)-x86.exe" Pack="true" PackagePath="runtimes\win7-x86\lib\net461\$(AssemblyName)-x86.exe" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.FunctionalTests/RuntimeFlavors.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.FunctionalTests/RuntimeFlavors.cs
@@ -15,11 +15,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.ViewCompilation
             get
             {
                 yield return RuntimeFlavor.CoreClr;
-                // Can't run on CLR until https://github.com/dotnet/corefx/issues/20364 is resolved.
-                //if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                //{
-                //    yield return RuntimeFlavor.Clr;
-                //}
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    yield return RuntimeFlavor.Clr;
+                }
             }
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.FunctionalTests/SimpleAppX86DesktopOnlyTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.FunctionalTests/SimpleAppX86DesktopOnlyTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.ViewCompilation
 
         public ApplicationTestFixture Fixture { get; }
 
-        [Fact(Skip = "https://github.com/dotnet/corefx/issues/20364")]
+        [Fact(Skip = "https://github.com/aspnet/MvcPrecompilation/issues/134")]
         public async Task Precompilation_WorksForSimpleApps()
         {
             // Arrange

--- a/testapps/ClassLibraryWithPrecompiledViews/ClassLibraryWithPrecompiledViews.csproj
+++ b/testapps/ClassLibraryWithPrecompiledViews/ClassLibraryWithPrecompiledViews.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <Target Name="PrecompileRazorViews" AfterTargets="Build" DependsOnTargets="MvcRazorPrecompile" Condition="'$(TargetFramework)'!='' AND '$(TargetFramework)'!='net461'" />
+  <Target Name="PrecompileRazorViews" AfterTargets="Build" DependsOnTargets="MvcRazorPrecompile" Condition="'$(TargetFramework)'!=''" />
 
 </Project>


### PR DESCRIPTION
- This also includes changes to manually pack the view compilation nupkg to ensure it can be used from x64 and x86 projects.

aspnet/Coherence-Signed#540