### PR TITLE
Use x64 binaries when project's targeting AnyCPU (#255)

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/build/netstandard2.0/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.targets
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/build/netstandard2.0/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.targets
@@ -85,8 +85,10 @@
     Condition="'$(MvcRazorCompileOnPublish)'=='true' AND '$(_MvcViewCompilationAddDesktopReferences)'!='false' AND '$(TargetFrameworkIdentifier)'=='.NETFramework'">
 
     <PropertyGroup Condition="'$(_MvcViewCompilationBinaryPath)'==''">
-      <_MvcViewCompilationBinaryPath Condition="'$(PlatformTarget)'=='x64'">$(MSBuildThisFileDirectory)$(MSBuildThisFileName)-x64.exe</_MvcViewCompilationBinaryPath>
       <_MvcViewCompilationBinaryPath Condition="'$(PlatformTarget)'=='x86'">$(MSBuildThisFileDirectory)$(MSBuildThisFileName)-x86.exe</_MvcViewCompilationBinaryPath>
+
+      <!-- For PlatformTarget = AnyCPU or x64, we will use the x64 binary -->
+      <_MvcViewCompilationBinaryPath Condition="'$(_MvcViewCompilationBinaryPath)'==''">$(MSBuildThisFileDirectory)$(MSBuildThisFileName)-x64.exe</_MvcViewCompilationBinaryPath>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(_MvcViewCompilationBinaryPath)'!=''">
@@ -99,18 +101,22 @@
     DependsOnTargets="_AddDesktopReferences;_CreateResponseFileForMvcRazorPrecompile"
     Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
 
+    <PropertyGroup>
+      <_MvcViewCompilationBinaryName>$([System.IO.Path]::GetFileName('$(_MvcViewCompilationBinaryPath)'))</_MvcViewCompilationBinaryName>
+    </PropertyGroup>
+
     <ItemGroup>
       <_PreCompilationFilesToCopy
         Include="$(OutputPath)$(AssemblyName).exe.config"
-        Destination="$(OutputPath)$(MSBuildThisFileName)-$(PlatformTarget).exe.config" />
+        Destination="$(OutputPath)$(_MvcViewCompilationBinaryName).config" />
 
       <_PreCompilationFilesToCopy
         Include="$(_MvcViewCompilationBinaryPath)"
-        Destination="$(OutputPath)$(MSBuildThisFileName)-$(PlatformTarget).exe" />
+        Destination="$(OutputPath)$(_MvcViewCompilationBinaryName)" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(MvcRazorRunCommand)'==''">
-      <MvcRazorRunCommand>$(OutputPath)$(MSBuildThisFileName)-$(PlatformTarget).exe</MvcRazorRunCommand>
+      <MvcRazorRunCommand>$(OutputPath)$(_MvcViewCompilationBinaryName)</MvcRazorRunCommand>
     </PropertyGroup>
 
     <Copy

--- a/test/FunctionalTests/DesktopTests/SimpleAppTest_WithAnyCPU_Desktop.cs
+++ b/test/FunctionalTests/DesktopTests/SimpleAppTest_WithAnyCPU_Desktop.cs
@@ -11,12 +11,11 @@ using Xunit.Abstractions;
 
 namespace FunctionalTests
 {
-    [OSSkipCondition(OperatingSystems.Linux)]
-    [OSSkipCondition(OperatingSystems.MacOSX)]
-    public class PublishWithDebugTest_Desktop :
-        LoggedTest, IClassFixture<PublishWithDebugTest_Desktop.TestFixture>
+    [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+    public class SimpleAppTest_WithAnyCPU_Desktop :
+        LoggedTest, IClassFixture<SimpleAppTest_WithAnyCPU_Desktop.TestFixture>
     {
-        public PublishWithDebugTest_Desktop(
+        public SimpleAppTest_WithAnyCPU_Desktop(
             TestFixture fixture,
             ITestOutputHelper output)
             : base(output)
@@ -27,16 +26,16 @@ namespace FunctionalTests
         public ApplicationTestFixture Fixture { get; }
 
         [ConditionalFact]
-        public async Task PublishingInDebugWorks()
+        public async Task Precompilation_WorksForSimpleApps_BuiltWithPlatformTargetAnyCPU()
         {
             using (StartLog(out var loggerFactory))
             {
                 // Arrange
                 var deployment = await Fixture.CreateDeploymentAsync(loggerFactory);
 
-                // Assert
-                var expected = Path.Combine(deployment.ContentRoot, $"{Fixture.ApplicationName}.PrecompiledViews.dll");
-                Assert.True(File.Exists(expected), $"File {expected} does not exist.");
+                // Act & Assert
+                var dllFile = Path.Combine(deployment.ContentRoot, "SimpleApp.PrecompiledViews.dll");
+                Assert.True(File.Exists(dllFile), $"{dllFile} exists at deployment.");
             }
         }
 
@@ -50,7 +49,7 @@ namespace FunctionalTests
             protected override DeploymentParameters GetDeploymentParameters()
             {
                 var deploymentParameters = base.GetDeploymentParameters();
-                deploymentParameters.Configuration = "Debug";
+                deploymentParameters.AdditionalPublishParameters = "/p:PlatformTarget=AnyCPU";
 
                 return deploymentParameters;
             }

--- a/test/FunctionalTests/FunctionalTests.csproj
+++ b/test/FunctionalTests/FunctionalTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DeveloperBuild)'!='true'">$(TargetFrameworks);netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
 
     <DefineConstants>$(DefineConstants);__remove_this_to__GENERATE_BASELINES</DefineConstants>
     <DefineConstants Condition="'$(GenerateBaseLines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
@@ -33,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\testapps\ApplicationUsingPrecompiledViewClassLibrary\ApplicationUsingPrecompiledViewClassLibrary.csproj" />
     <ProjectReference Include="..\..\testapps\ApplicationUsingRelativePaths\ApplicationUsingRelativePaths.csproj" />
     <ProjectReference Include="..\..\testapps\ApplicationWithConfigureMvc\ApplicationWithConfigureMvc.csproj" />
     <ProjectReference Include="..\..\testapps\ApplicationWithCustomInputFiles\ApplicationWithCustomInputFiles.csproj" />


### PR DESCRIPTION
* Use x64 binaries when project's targeting AnyCPU

Fixes https://github.com/aspnet/MvcPrecompilation/issues/240

NOTE: This repo is solely for maintenance of the existing MVC precompilation feature. Future work on Razor compilation is now being handled in the [Razor](https://github.com/aspnet/razor) repo. See [aspnet/Razor#1740](https://github.com/aspnet/Razor/issues/1740) for additional details.
