### PR TITLE
Disable APICheck on precompilation to workaround failure

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
@@ -10,6 +10,7 @@
     <OutputType>exe</OutputType>
     <TasksProjectDirectory>..\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Tasks\</TasksProjectDirectory>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net461'">


### PR DESCRIPTION
Build error: 

`\.packages\internal.aspnetcore.sdk\2.1.0-preview2-15749\build\ApiCheck.targets(20,5): error : Unhandled Exception: System.BadImageFormatException: Could not load file or assembly 'Microsoft.DiaSymReader.Native.x86.dll' or one of its dependencies. The module was expected to contain an assembly manifest`