### PR TITLE
Disable APICheck on precompilation to workaround failure

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
@@ -10,6 +10,7 @@
     <OutputType>exe</OutputType>
     <TasksProjectDirectory>..\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Tasks\</TasksProjectDirectory>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net461'">


### PR DESCRIPTION
NOTE: This repo is solely for maintenance of the existing MVC precompilation feature. Future work on Razor compilation is now being handled in the [Razor](https://github.com/aspnet/razor) repo. See [aspnet/Razor#1740](https://github.com/aspnet/Razor/issues/1740) for additional details.
