### PR TITLE
Compiling a 2.1.0 project targeting desktop with a reference to the ViewCompilation package produces a warning about mismatch in architectures

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
@@ -13,15 +13,6 @@
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
-    <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
-    <PlatformTarget Condition="'$(Platform)'=='AnyCPU'">x86</PlatformTarget>
-    <AssemblyName>$(AssemblyName)-$(PlatformTarget)</AssemblyName>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>bin\$(Configuration)\net461\win7-$(PlatformTarget)</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\net461\win7-$(PlatformTarget)</IntermediateOutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(TasksProjectDirectory)Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Tasks.csproj" PrivateAssets="true" ReferenceOutputAssembly="false" />
 
@@ -31,21 +22,27 @@
     <PackageReference Update="Microsoft.NETCore.App" PrivateAssets="All" />
   </ItemGroup>
 
-  <Target Name="BuildX64" AfterTargets="Build" Condition="'$(TargetFramework)'=='net461' AND '$(PlatformTarget)'!='x64'">
+  <Target Name="BuildX86" AfterTargets="Build" Condition="'$(TargetFramework)'=='net461' AND '$(PlatformTarget)'!='x86'">
     <MSBuild
       Projects="$(MSBuildProjectFullPath)"
       Targets="Build"
       Properties="
         Configuration=$(Configuration);
-        TargetFramework=net461;
-        Platform=x64;" />
+        TargetFramework=$(TargetFramework);
+        Platform=x86;
+        BuildNumber=$(BuildNumber);
+        OutputPath=$(OutputPath);
+        TargetName=$(TargetName)-x86" />
   </Target>
 
-  <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="BuildX64;">
+  <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="BuildX86">
 
     <PropertyGroup>
       <!-- Make sure we create a symbols.nupkg. -->
       <IncludeSymbols>true</IncludeSymbols>
+
+      <!-- RepositoryCommit is only available when "build" runs, but not during dotnet pack -->
+      <RepositoryCommit Condition="'$(RepositoryCommit)' == ''">unknown</RepositoryCommit>
 
       <NuspecProperties>
         id=$(PackageId);
@@ -66,10 +63,10 @@
         TaskBinary=$(TasksProjectDirectory)bin\$(Configuration)\netstandard2.0\$(AssemblyName).Tasks.dll;
         TaskSymbol=$(TasksProjectDirectory)bin\$(Configuration)\netstandard2.0\$(AssemblyName).Tasks.pdb;
 
-        OutputExeX86=$(OutputPath)net461\win7-x86\$(AssemblyName)-x86.exe;
-        OutputExeSymbolX86=$(OutputPath)net461\win7-x86\$(AssemblyName)-x86.pdb;
-        OutputExeX64=$(OutputPath)net461\win7-x64\$(AssemblyName)-x64.exe;
-        OutputExeSymbolX64=$(OutputPath)net461\win7-x64\$(AssemblyName)-x64.pdb;
+        OutputExeX86=$(OutputPath)net461\$(AssemblyName)-x86.exe;
+        OutputExeSymbolX86=$(OutputPath)net461\$(AssemblyName)-x86.pdb;
+        OutputExeAnyCPU=$(OutputPath)net461\$(AssemblyName).exe;
+        OutputExeSymbolAnyCPU=$(OutputPath)net461\$(AssemblyName).pdb;
       </NuspecProperties>
     </PropertyGroup>
   </Target>

--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.nuspec
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.nuspec
@@ -26,13 +26,17 @@
 
   <files>
     <file src="build\**\*" target="build\" />
-    <file src="$OutputBinary$" target="build\netstandard2.0\$AssemblyName$.dll" />
-    <file src="$OutputSymbol$" target="build\netstandard2.0\$AssemblyName$.pdb" />
+
+    <file src="$OutputBinary$" target="build\netstandard2.0\netcoreapp2.0\" />
+    <file src="$OutputSymbol$" target="build\netstandard2.0\netcoreapp2.0\" />
+
+    <file src="$OutputExeX86$" target="build\netstandard2.0\net461\" />
+    <file src="$OutputExeSymbolX86$" target="build\netstandard2.0\net461\" />
+
+    <file src="$OutputExeAnyCPU$" target="build\netstandard2.0\net461\" />
+    <file src="$OutputExeSymbolAnyCPU$" target="build\netstandard2.0\net461\" />
+
     <file src="$TaskBinary$" target="build\netstandard2.0\$AssemblyName$.Tasks.dll" />
     <file src="$TaskSymbol$" target="build\netstandard2.0\$AssemblyName$.Tasks.pdb" />
-    <file src="$OutputExeX86$" target="build\netstandard2.0\" />
-    <file src="$OutputExeSymbolX86$" target="build\netstandard2.0\" />
-    <file src="$OutputExeX64$" target="build\netstandard2.0\" />
-    <file src="$OutputExeSymbolX64$" target="build\netstandard2.0\" />
   </files>
 </package>

--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/build/netstandard2.0/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.targets
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/build/netstandard2.0/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.targets
@@ -51,7 +51,8 @@
 
     <PropertyGroup>
       <MvcRazorRunCommand Condition="'$(MvcRazorRunCommand)'==''">dotnet</MvcRazorRunCommand>
-      <_MvcViewCompilationBinaryPath Condition="'$(_MvcViewCompilationBinaryPath)'==''">$(MSBuildThisFileDirectory)$(MSBuildThisFileName).dll</_MvcViewCompilationBinaryPath>
+      <_MvcViewCompilationBinariesDir Condition="'$(_MvcViewCompilationBinariesDir)' == ''">$(MSBuildThisFileDirectory)</_MvcViewCompilationBinariesDir>
+      <_MvcViewCompilationBinaryPath>$(_MvcViewCompilationBinariesDir)netcoreapp2.0\$(MSBuildThisFileName).dll</_MvcViewCompilationBinaryPath>
 
       <ExecArgs>&quot;$(MvcRazorRunCommand)&quot; exec</ExecArgs>
       <ExecArgs>$(ExecArgs) --runtimeconfig &quot;$(ProjectRuntimeConfigFilePath)&quot;</ExecArgs>
@@ -79,17 +80,19 @@
       Targets="Build;MvcRazorPrecompile" />
   </Target>
 
+  <Target Name="_ResolveBinaryPath">
+    <PropertyGroup>
+      <_MvcViewCompilationBinariesDir Condition="'$(_MvcViewCompilationBinariesDir)' == ''">$(MSBuildThisFileDirectory)</_MvcViewCompilationBinariesDir>
+
+      <_MvcViewCompilationBinaryPath Condition="'$(PlatformTarget)'=='x86'">$(_MvcViewCompilationBinariesDir)net461\$(MSBuildThisFileName)-x86.exe</_MvcViewCompilationBinaryPath>
+      <_MvcViewCompilationBinaryPath Condition="'$(PlatformTarget)'!='x86'">$(_MvcViewCompilationBinariesDir)net461\$(MSBuildThisFileName).exe</_MvcViewCompilationBinaryPath>
+    </PropertyGroup>
+  </Target>
+
   <Target
     Name="_AddDesktopReferences"
     AfterTargets="ResolveLockFileReferences"
-    Condition="'$(MvcRazorCompileOnPublish)'=='true' AND '$(_MvcViewCompilationAddDesktopReferences)'!='false' AND '$(TargetFrameworkIdentifier)'=='.NETFramework'">
-
-    <PropertyGroup Condition="'$(_MvcViewCompilationBinaryPath)'==''">
-      <_MvcViewCompilationBinaryPath Condition="'$(PlatformTarget)'=='x86'">$(MSBuildThisFileDirectory)$(MSBuildThisFileName)-x86.exe</_MvcViewCompilationBinaryPath>
-
-      <!-- For PlatformTarget = AnyCPU or x64, we will use the x64 binary -->
-      <_MvcViewCompilationBinaryPath Condition="'$(_MvcViewCompilationBinaryPath)'==''">$(MSBuildThisFileDirectory)$(MSBuildThisFileName)-x64.exe</_MvcViewCompilationBinaryPath>
-    </PropertyGroup>
+    Condition="'$(MvcRazorCompileOnPublish)'=='true' AND '$(ResolvedRazorCompileToolset)'=='PrecompilationTool' AND '$(TargetFrameworkIdentifier)'=='.NETFramework'">
 
     <ItemGroup Condition="'$(_MvcViewCompilationBinaryPath)'!=''">
       <Reference Include="$(_MvcViewCompilationBinaryPath)" Private="false" Visible="false" />
@@ -98,7 +101,7 @@
 
   <Target
     Name="_RunForDesktop"
-    DependsOnTargets="_AddDesktopReferences;_CreateResponseFileForMvcRazorPrecompile"
+    DependsOnTargets="_ResolveBinaryPath;_AddDesktopReferences;_CreateResponseFileForMvcRazorPrecompile"
     Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
 
     <PropertyGroup>
@@ -165,11 +168,11 @@
      Name="_MvcRazorPrecompileOnPublish"
      DependsOnTargets="MvcRazorPrecompile"
      AfterTargets="PrepareForPublish"
-     Condition="'$(ResolvedRazorCompileToolset)'=='PrecompilationTool'and '$(MvcRazorCompileOnPublish)'=='true'" />
+     Condition="'$(ResolvedRazorCompileToolset)'=='PrecompilationTool' and '$(MvcRazorCompileOnPublish)'=='true'" />
 
   <Target Name="_MvcRazorResolveFilesToCompute"
     AfterTargets="ComputeRefAssembliesToPublish"
-    Condition="'$(ResolvedRazorCompileToolset)'=='PrecompilationTool'and '$(MvcRazorCompileOnPublish)'=='true'">
+    Condition="'$(ResolvedRazorCompileToolset)'=='PrecompilationTool' and '$(MvcRazorCompileOnPublish)'=='true'">
 
     <PropertyGroup>
       <_MvcRazorOutputPdbFullPath>$([System.IO.Path]::ChangeExtension('$(_MvcRazorOutputFullPath)', '.pdb'))</_MvcRazorOutputPdbFullPath>

--- a/testapps/Directory.Build.targets
+++ b/testapps/Directory.Build.targets
@@ -2,22 +2,12 @@
   <Import Project="..\Directory.Build.targets" />
 
   <PropertyGroup>
-    <_MvcViewCompilationAddDesktopReferences>false</_MvcViewCompilationAddDesktopReferences>
     <TestIncludeViewCompilationTargets Condition="'$(TestIncludeViewCompilationTargets)'==''">$(MvcRazorCompileOnPublish)</TestIncludeViewCompilationTargets>
     <SolutionConfiguration Condition="'$(SolutionConfiguration)'==''">$(Configuration)</SolutionConfiguration>
     <_MvcViewCompilationTasksPath>$(MSBuildThisFileDirectory)..\src\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Tasks\bin\$(SolutionConfiguration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Tasks.dll</_MvcViewCompilationTasksPath>
+    <_MvcViewCompilationBinariesDir>$(MSBuildThisFileDirectory)..\src\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation\bin\$(SolutionConfiguration)\</_MvcViewCompilationBinariesDir>
   </PropertyGroup>
 
   <Import Project="..\src\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.targets"
     Condition="'$(TestIncludeViewCompilationTargets)'=='true'"/>
-
-  <Target
-    Name="SetMvcRazorViewCompilationBinaryPath"
-    BeforeTargets="MvcRazorPrecompile"
-    Condition="'$(TestIncludeViewCompilationTargets)'=='true'">
-    <PropertyGroup>
-      <_MvcViewCompilationBinaryPath Condition="'$(TargetFramework)'!='net461'">$(MSBuildThisFileDirectory)..\src\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation\bin\$(SolutionConfiguration)\netcoreapp2.0\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.dll</_MvcViewCompilationBinaryPath>
-      <_MvcViewCompilationBinaryPath Condition="'$(TargetFramework)'=='net461'">$(MSBuildThisFileDirectory)..\src\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation\bin\$(SolutionConfiguration)\net461\win7-x86\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation-x86.exe</_MvcViewCompilationBinaryPath>
-    </PropertyGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
Fixes #270
