### PR TITLE
Fix dependency versions for Hosting and Mvc.RazorPages

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
@@ -51,6 +51,8 @@
         id=$(PackageId);
         version=$(PackageVersion);
         authors=$(Authors);
+        MicrosoftAspNetCoreHostingPackageVersion=$(MicrosoftAspNetCoreHostingPackageVersion);
+        MicrosoftAspNetCoreMvcRazorPagesPackageVersion=$(MicrosoftAspNetCoreMvcRazorPagesPackageVersion);
         description=$(Description);
         tags=$(PackageTags.Replace(';', ' '));
         licenseUrl=$(PackageLicenseUrl);

--- a/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.nuspec
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.nuspec
@@ -14,12 +14,12 @@
     <repository type="git" url="$repositoryUrl$" commit="$repositoryCommit$" />
     <dependencies>
       <group targetFramework=".NETFramework4.6.1">
-        <dependency id="Microsoft.AspNetCore.Hosting" version="$version$" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.AspNetCore.Mvc.RazorPages" version="$version$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.Hosting" version="$MicrosoftAspNetCoreHostingPackageVersion$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.Mvc.RazorPages" version="$MicrosoftAspNetCoreMvcRazorPagesPackageVersion$" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETCoreApp2.0">
-        <dependency id="Microsoft.AspNetCore.Hosting" version="$version$" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.AspNetCore.Mvc.RazorPages" version="$version$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.Hosting" version="$MicrosoftAspNetCoreHostingPackageVersion$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.Mvc.RazorPages" version="$MicrosoftAspNetCoreMvcRazorPagesPackageVersion$" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Fix the nuspec which incorrectly assumed the version of Microsoft.AspNetCore.Mvc.Razor.ViewCompilation matches the version of its dependencies. 